### PR TITLE
Add Template include path variable to Mojolicious renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ nytprof.out
 *.o
 *.bs
 /_eumm/
+**.swp
 /Mojolicious-Plugin-TemplateToolkit-*

--- a/lib/Mojolicious/Plugin/TemplateToolkit.pm
+++ b/lib/Mojolicious/Plugin/TemplateToolkit.pm
@@ -11,8 +11,9 @@ sub register {
 	my ($self, $app, $conf) = @_;
 	
 	my $tt_config = $conf->{template} || {};
-	if ($tt_config->{INCLUDE_PATH}) {
-	    push(@{$app->renderer->paths}, $tt_config->{INCLUDE_PATH});
+	my $incl_path = $tt_config->{INCLUDE_PATH};
+	if (defined $incl_path) {
+	    push(@{$app->renderer->paths}, ref($incl_path) eq 'ARRAY' ? @$incl_path : $incl_path);
 	}
 	$tt_config->{MOJO_RENDERER} = $app->renderer;
 	push @{$tt_config->{LOAD_TEMPLATES}}, Template::Provider::Mojo->new($tt_config);
@@ -137,6 +138,9 @@ Handler name, defaults to C<tt2>.
  plugin TemplateToolkit => {template => {INTERPOLATE => 1}};
 
 Configuration values passed to L<Template> object used to render templates.
+
+When configuration contains a C<INCLUDE_PATH> value, will automatically
+push that to the Mojolicious rendering paths.
 
 =head1 METHODS
 

--- a/lib/Mojolicious/Plugin/TemplateToolkit.pm
+++ b/lib/Mojolicious/Plugin/TemplateToolkit.pm
@@ -11,8 +11,7 @@ sub register {
 	my ($self, $app, $conf) = @_;
 	
 	my $tt_config = $conf->{template} || {};
-	my $incl_path = $tt_config->{INCLUDE_PATH};
-	if (defined $incl_path) {
+	if (my $incl_path = $tt_config->{INCLUDE_PATH}) {
 	    push(@{$app->renderer->paths}, ref($incl_path) eq 'ARRAY' ? @$incl_path : $incl_path);
 	}
 	$tt_config->{MOJO_RENDERER} = $app->renderer;

--- a/lib/Mojolicious/Plugin/TemplateToolkit.pm
+++ b/lib/Mojolicious/Plugin/TemplateToolkit.pm
@@ -11,6 +11,9 @@ sub register {
 	my ($self, $app, $conf) = @_;
 	
 	my $tt_config = $conf->{template} || {};
+	if ($tt_config->{INCLUDE_PATH}) {
+	    push(@{$app->renderer->paths}, $tt_config->{INCLUDE_PATH});
+	}
 	$tt_config->{MOJO_RENDERER} = $app->renderer;
 	push @{$tt_config->{LOAD_TEMPLATES}}, Template::Provider::Mojo->new($tt_config);
 	my $tt = Template->new($tt_config);

--- a/t/renderer.t
+++ b/t/renderer.t
@@ -2,6 +2,8 @@ use Mojo::Base -strict;
 
 use Test::More;
 use Mojolicious;
+use Path::Tiny;
+use FindBin qw($Bin);
 
 # Partial rendering
 my $app = Mojolicious->new(secrets => ['works']);
@@ -37,5 +39,16 @@ $c->app->log->level('fatal');
 is $c->render_to_string(inline => 'foo', handler => 'foo'), 'foo', 'name works';
 is $c->render_to_string(inline => '$foo', handler => 'foo', foo => 'bar'), 'bar', 'interpolate works';
 is $c->render_to_string(inline => '<% foo %>', handler => 'foo', foo => 'bar'), 'bar', 'tags work';
+
+$app = Mojolicious->new(secrets => ['works']);
+$tt_config = { INTERPOLATE => 1, INCLUDE_PATH => $Bin . '/share/templates', DELIMITER => '/' };
+$app->plugin(TemplateToolkit => { name => 'tt2', template => $tt_config });
+$c = $app->build_controller;
+$c->app->log->level('fatal');
+#$c->app->log->handle(\*STDERR);
+like($c->render_to_string(template => 'test', handler => 'tt2', format => 'html', foo => 'bar'),
+    qr{<body>[\n\s]+bar[\n\s]+</body>},
+    'rendering from TT included path works'
+);
 
 done_testing();

--- a/t/renderer.t
+++ b/t/renderer.t
@@ -2,7 +2,6 @@ use Mojo::Base -strict;
 
 use Test::More;
 use Mojolicious;
-use Path::Tiny;
 use FindBin qw($Bin);
 
 # Partial rendering

--- a/t/share/templates/test.html.tt2
+++ b/t/share/templates/test.html.tt2
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Mojolicious-Plugin-TemplateToolkit Test</title>
+</head>
+<body>
+  [% foo %]
+</body>
+</html>


### PR DESCRIPTION
This pull request makes it so the caller doesn't have to manually push paths to Mojolicious when wanting to render templates from files.

I was recently using this plugin (thanks!) and came across the issue where I had specified the following config:

`$self->plugin('TemplateToolkit', { template => { INCLUDE_PATH => '/path/to/templates' } });`

but was getting returned with 404 template not found errors. Then I found it was because this path was being passed to Template but not to Mojolicious, hence this PR :)